### PR TITLE
SC-455: Define the current environment in config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
   "require": {
     "php": ">=7.1",
     "spryker-sdk/spryk": "^0.1.0 || ^0.2.0",
-    "spryker/config": "^3.1.3",
     "spryker/development": "^3.12.0",
     "spryker/graph": "^3.0.0",
     "spryker/kernel": "^3.0.0",

--- a/src/SprykerSdk/Zed/SprykGui/Business/ChoiceLoader/Zed/Business/Model/ZedBusinessModelChoiceLoader.php
+++ b/src/SprykerSdk/Zed/SprykGui/Business/ChoiceLoader/Zed/Business/Model/ZedBusinessModelChoiceLoader.php
@@ -62,6 +62,7 @@ class ZedBusinessModelChoiceLoader implements ChoiceLoaderInterface
             $moduleTransfer->getOrganization()->getName(),
             $moduleTransfer->getName()
         );
+
         return $moduleBusinessDirectory;
     }
 }

--- a/src/SprykerSdk/Zed/SprykGui/Communication/Controller/AbstractController.php
+++ b/src/SprykerSdk/Zed/SprykGui/Communication/Controller/AbstractController.php
@@ -7,7 +7,6 @@
 
 namespace SprykerSdk\Zed\SprykGui\Communication\Controller;
 
-use Spryker\Shared\Config\Environment;
 use Spryker\Zed\Kernel\Communication\Controller\AbstractController as SprykerAbstractController;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -18,6 +17,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class AbstractController extends SprykerAbstractController
 {
     /**
+     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     *
      * @return void
      */
     public function initialize(): void

--- a/src/SprykerSdk/Zed/SprykGui/Communication/Controller/AbstractController.php
+++ b/src/SprykerSdk/Zed/SprykGui/Communication/Controller/AbstractController.php
@@ -17,8 +17,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class AbstractController extends SprykerAbstractController
 {
     /**
-     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
-     *
      * @return void
      */
     public function initialize(): void

--- a/src/SprykerSdk/Zed/SprykGui/Communication/Controller/AbstractController.php
+++ b/src/SprykerSdk/Zed/SprykGui/Communication/Controller/AbstractController.php
@@ -34,10 +34,9 @@ class AbstractController extends SprykerAbstractController
      */
     protected function assertNonProductionEnvironment(): void
     {
-        $isProductionEnvironment = Environment::isProduction();
         $isCli = PHP_SAPI === 'cli';
 
-        if (!$isProductionEnvironment || $isCli) {
+        if ($isCli || $this->getFactory()->getConfig()->isSprykWebInterfaceEnabled()) {
             return;
         }
 

--- a/src/SprykerSdk/Zed/SprykGui/Communication/Controller/GraphController.php
+++ b/src/SprykerSdk/Zed/SprykGui/Communication/Controller/GraphController.php
@@ -14,7 +14,6 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 /**
  * @method \SprykerSdk\Zed\SprykGui\Communication\SprykGuiCommunicationFactory getFactory()
  * @method \SprykerSdk\Zed\SprykGui\Business\SprykGuiFacadeInterface getFacade()
- * @method \SprykerSdk\Zed\SprykGui\Persistence\SprykGuiQueryContainerInterface getQueryContainer()
  */
 class GraphController extends AbstractController
 {

--- a/src/SprykerSdk/Zed/SprykGui/Communication/Controller/ListController.php
+++ b/src/SprykerSdk/Zed/SprykGui/Communication/Controller/ListController.php
@@ -10,7 +10,6 @@ namespace SprykerSdk\Zed\SprykGui\Communication\Controller;
 /**
  * @method \SprykerSdk\Zed\SprykGui\Communication\SprykGuiCommunicationFactory getFactory()
  * @method \SprykerSdk\Zed\SprykGui\Business\SprykGuiFacadeInterface getFacade()
- * @method \SprykerSdk\Zed\SprykGui\Persistence\SprykGuiQueryContainerInterface getQueryContainer()
  */
 class ListController extends AbstractController
 {

--- a/src/SprykerSdk/Zed/SprykGui/SprykGuiConfig.php
+++ b/src/SprykerSdk/Zed/SprykGui/SprykGuiConfig.php
@@ -7,7 +7,6 @@
 
 namespace SprykerSdk\Zed\SprykGui;
 
-use Spryker\Shared\Config\Config;
 use Spryker\Shared\Kernel\KernelConstants;
 use Spryker\Zed\Kernel\AbstractBundleConfig;
 
@@ -18,7 +17,7 @@ class SprykGuiConfig extends AbstractBundleConfig
      */
     public function getCoreNamespaces(): array
     {
-        return Config::get(KernelConstants::CORE_NAMESPACES, []);
+        return $this->get(KernelConstants::CORE_NAMESPACES, []);
     }
 
     /**
@@ -26,6 +25,14 @@ class SprykGuiConfig extends AbstractBundleConfig
      */
     public function getProjectNamespaces(): array
     {
-        return Config::get(KernelConstants::PROJECT_NAMESPACES, []);
+        return $this->get(KernelConstants::PROJECT_NAMESPACES, []);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSprykWebInterfaceEnabled(): bool
+    {
+        return $this->getEnvironmentName() !== 'production';
     }
 }

--- a/src/SprykerSdk/Zed/SprykGui/SprykGuiConfig.php
+++ b/src/SprykerSdk/Zed/SprykGui/SprykGuiConfig.php
@@ -29,10 +29,12 @@ class SprykGuiConfig extends AbstractBundleConfig
     }
 
     /**
+     * @deprecated Method will be removed without replacement.
+     *
      * @return bool
      */
     public function isSprykWebInterfaceEnabled(): bool
     {
-        return $this->getEnvironmentName() !== 'production';
+        return APPLICATION_ENV !== 'production';
     }
 }


### PR DESCRIPTION
 Developer(s): @alexanderM91 

- Ticket: https://spryker.atlassian.net/browse/SC-455

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/1457

- Core PR:  https://github.com/spryker/spryker/pull/5500
- Shop PR: https://github.com/spryker/spryker-shop/pull/1000
- Suite non-split PR: https://github.com/spryker/suite-nonsplit/pull/2312

#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SprykGui                | patch (currently 0.x)                 |                     |
   

#### Release Notes

Application behavior is controlled via explicit configuration settings instead of environment names.

-----------------------------------------

##### Module SprykGui

##### Change log

- Introduced `SprykGuiConfig::isSprykWebInterfaceEnabled()` to enable/disable Spryk web interface.