### PR TITLE
TE-3794 Use array instead of string for Process.

### DIFF
--- a/src/SprykerSdk/Zed/SprykGui/Business/Spryk/Spryk.php
+++ b/src/SprykerSdk/Zed/SprykGui/Business/Spryk/Spryk.php
@@ -87,7 +87,7 @@ class Spryk implements SprykInterface
     {
         $normalizedFormData = (new FormDataNormalizer())->normalizeFormData($formData);
         $commandLine = $this->getCommandLine($sprykName, $normalizedFormData);
-        $process = new Process($commandLine, APPLICATION_ROOT_DIR);
+        $process = $this->getProcess($commandLine);
         $process->run();
 
         if ($process->isSuccessful()) {
@@ -95,6 +95,20 @@ class Spryk implements SprykInterface
         }
 
         return $process->getErrorOutput();
+    }
+
+    /**
+     * @param string $commandLine
+     *
+     * @return \Symfony\Component\Process\Process
+     */
+    protected function getProcess(string $commandLine): Process
+    {
+        if (method_exists(Process::class, 'fromShellCommandline')) {
+            return Process::fromShellCommandline($commandLine, APPLICATION_ROOT_DIR);
+        }
+
+        return new Process($commandLine, APPLICATION_ROOT_DIR);
     }
 
     /**


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-3794

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   SprykGui              | patch (currently 0.x)  |                       |

#### Release Notes

Updated code which makes use of Symfony's Process component. Switched from string to array for the command line argument.

-----------------------------------------

#### Module SprykGui

##### Change log

Bugfixes

- Switched from string to array for the command line argument.

